### PR TITLE
Add link to the `rails_best_practices` gem

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ _List inspired by the [awesome](https://github.com/sindresorhus/awesome) list th
 - [git-secrets](https://github.com/awslabs/git-secrets) - Prevents you from committing secrets and credentials into git repositories.
 - [DevSkim](https://github.com/Microsoft/DevSkim) - DevSkim is a set of IDE plugins and rules that provide security "linting" capabilities. Also has support for CLI so it can be integrated into CI/CD pipeline.
 - [ban-sensitive-files](https://github.com/bahmutov/ban-sensitive-files) - Checks filenames to be committed against a library of filename rules to prevent storing sensitive files in Git. Checks some files for sensitive contents (for example authToken inside .npmrc file).
+- [rails_best_practices](https://github.com/flyerhzm/rails_best_practices) - A static code analyzer for Ruby on Rails applications that finds - among other things - common patterns that might lead to security vulnerabilities.
 
 ## Vulnerabilities and Security Advisories
 


### PR DESCRIPTION
Hi there,

I think the `rails_best_practices` gem is a helpful tool to find common sources of security vulnerabilities in Ruby on Rails application.