### PR TITLE
Add Ruby Advisory Database

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ _List inspired by the [awesome](https://github.com/sindresorhus/awesome) list th
 ## Vulnerabilities and Security Advisories
 
 - [bundler-audit](https://rubygems.org/gems/bundler-audit) - Patch-level verification for Ruby apps.
+- [ruby-advisory-db](https://github.com/rubysec/ruby-advisory-db) - Open source database of security advisories that are relevant to Ruby libraries.
 
 # Educational
 


### PR DESCRIPTION
The [ruby-advisory-db](https://github.com/rubysec/ruby-advisory-db) is the DB of security advisories that Bundle Audit, amongst others, uses. It's community maintained and basically public domain (there's a slight complication with the OSVDB license, but since that org is now defunct I'm pretty sure everything is just public).